### PR TITLE
Convert output to long

### DIFF
--- a/Libraries/MBZ.AdventOfCode.Core/Solvers/DaySolution.cs
+++ b/Libraries/MBZ.AdventOfCode.Core/Solvers/DaySolution.cs
@@ -76,7 +76,7 @@ public abstract class DaySolution : IDaySolutionDefinition
         }));
 
         // Run the requested puzzle part
-        Func<bool, string[], Action<OutputMessage>, int> puzzlePartRunner = puzzlePart switch
+        Func<bool, string[], Action<OutputMessage>, long> puzzlePartRunner = puzzlePart switch
         {
             PuzzlePart.Part1 => RunPart1,
             PuzzlePart.Part2 => RunPart2,
@@ -85,7 +85,7 @@ public abstract class DaySolution : IDaySolutionDefinition
 
         var expectedResultAttribute = puzzlePartRunner.GetMethodInfo().GetCustomAttribute<ExpectedResultAttribute>();
         var expectedResult = expectedResultAttribute == null 
-            ? int.MinValue
+            ? (long)0
             : useTestInput
                 ? expectedResultAttribute.TestResult
                 : expectedResultAttribute.Result
@@ -125,20 +125,20 @@ public abstract class DaySolution : IDaySolutionDefinition
     }
 
     [ExpectedResult(testResult: int.MinValue, result: int.MinValue)]
-    public virtual int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public virtual long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         output(new("Puzzle Solver has not yet implemented [RunPart1] method!"));
         return -1;
     }
 
     [ExpectedResult(testResult: int.MinValue, result: int.MinValue)]
-    public virtual int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public virtual long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         output(new("Puzzle Solver has not yet implemented [RunPart2] method!"));
         return -1;
     }
 
-    private static TimeSpan RunWithTimer(int expectedResult, Func<int> codeToTime, Action<PostPuzzleSolverRunResult> handleResult, Action<Exception> handleException)
+    private static TimeSpan RunWithTimer(long expectedResult, Func<long> codeToTime, Action<PostPuzzleSolverRunResult> handleResult, Action<Exception> handleException)
     {
         var watch = Stopwatch.StartNew();
 

--- a/Libraries/MBZ.AdventOfCode.Core/Solvers/ExpectedResultAttribute.cs
+++ b/Libraries/MBZ.AdventOfCode.Core/Solvers/ExpectedResultAttribute.cs
@@ -1,8 +1,8 @@
 ﻿namespace MBZ.AdventOfCode.Core.Solvers;
 
 [AttributeUsage(AttributeTargets.Method)]
-public class ExpectedResultAttribute(int testResult, int result) : Attribute
+public class ExpectedResultAttribute(long testResult, long result) : Attribute
 {
-    public int TestResult { get; } = testResult;
-    public int Result { get; } = result;
+    public long TestResult { get; } = testResult;
+    public long Result { get; } = result;
 }

--- a/Libraries/MBZ.AdventOfCode.Core/Solvers/PostPuzzleSolverRunResult.cs
+++ b/Libraries/MBZ.AdventOfCode.Core/Solvers/PostPuzzleSolverRunResult.cs
@@ -1,6 +1,6 @@
 ﻿namespace MBZ.AdventOfCode.Core.Solvers;
 
-public record PostPuzzleSolverRunResult(int Expected, int Result)
+public record PostPuzzleSolverRunResult(long Expected, long Result)
 {
     public bool Success => Expected == Result;
 }

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day01/Day01.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day01/Day01.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day01;
 public class Day01 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: 11, result: 1660292)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var (list1, list2) = input.ParseDay01Input();
         var distance = list1.CalculateTotalDistanceToList(list2);
@@ -18,7 +18,7 @@ public class Day01 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: 31, result: 22776016)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var (list1, list2) = input.ParseDay01Input();
         var similarityScore = list1.CalculateSimilarityScore(list2);

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day02/Day02.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day02/Day02.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day02;
 public class Day02 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: 2, result: 670)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var reports = input.ParseDay02Input();
         var safeReports = reports
@@ -21,7 +21,7 @@ public class Day02 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: 4, result: 700)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var reports = input.ParseDay02Input();
         var safeReports = reports

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day03/Day03.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day03/Day03.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day03;
 public class Day03 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: 161, result: 161085926)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var multiplyInstructions = input.GetMultiplyInstructions();
         var multiplicationSum = multiplyInstructions.ProductSum();
@@ -19,7 +19,7 @@ public class Day03 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: 48, result: 82045421)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var instructions = input.GetEnhancedInstructions();
         var multiplicationSum = instructions.EnhancedProductSum();

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day04/Day04.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day04/Day04.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day04;
 public class Day04 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: 18, result: 2458)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var grid = new WordSearchGrid(input);
         var xmasOccurrences = grid.CalculateXmasOccurrences();
@@ -20,7 +20,7 @@ public class Day04 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: 9, result: 1945)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var grid = new WordSearchGrid(input);
 

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day05/Day05.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day05/Day05.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day05;
 public class Day05 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: 143, result: 4814)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var (rules, updates) = input.ParseToDay05Data();
 
@@ -31,7 +31,7 @@ public class Day05 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: 123, result: 5448)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var (rules, updates) = input.ParseToDay05Data();
         var incorrectUpdates = updates.Where(rules.IsNotValidUpdate).Select(upd => new { Invalid = upd, Fixed = rules.FixIncorrectUpdate(upd) }).ToList();

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day06/Day06.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day06/Day06.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day06;
 public class Day06 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: 41, result: 5269)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var (map, guard) = input.ParseToDay06Data();
         map.SimulateGuardMovements(guard, out var totalMovements, out var isLooped);
@@ -21,7 +21,7 @@ public class Day06 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: 6, result: 1957)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var (map, guard) = input.ParseToDay06Data();
         var obstructionPositions = map.CalculateHowManyPositionsForObstructionToPlaceGuardInLoop(guard, out var positionsChecked);

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day07/Day07.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day07/Day07.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day07;
 public class Day07 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay07Data();
 
@@ -17,7 +17,7 @@ public class Day07 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay07Data();
 

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day08/Day08.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day08/Day08.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day08;
 public class Day08 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay08Data();
 
@@ -17,7 +17,7 @@ public class Day08 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay08Data();
 

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day09/Day09.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day09/Day09.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day09;
 public class Day09 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay09Data();
 
@@ -17,7 +17,7 @@ public class Day09 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay09Data();
 

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day10/Day10.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day10/Day10.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day10;
 public class Day10 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay10Data();
 
@@ -17,7 +17,7 @@ public class Day10 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay10Data();
 

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day11/Day11.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day11/Day11.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day11;
 public class Day11 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay11Data();
 
@@ -17,7 +17,7 @@ public class Day11 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay11Data();
 

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day12/Day12.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day12/Day12.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day12;
 public class Day12 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay12Data();
 
@@ -17,7 +17,7 @@ public class Day12 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay12Data();
 

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day13/Day13.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day13/Day13.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day13;
 public class Day13 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay13Data();
 
@@ -17,7 +17,7 @@ public class Day13 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay13Data();
 

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day14/Day14.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day14/Day14.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day14;
 public class Day14 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay14Data();
 
@@ -17,7 +17,7 @@ public class Day14 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay14Data();
 

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day15/Day15.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day15/Day15.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day15;
 public class Day15 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay15Data();
 
@@ -17,7 +17,7 @@ public class Day15 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay15Data();
 

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day16/Day16.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day16/Day16.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day16;
 public class Day16 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay16Data();
 
@@ -17,7 +17,7 @@ public class Day16 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay16Data();
 

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day17/Day17.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day17/Day17.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day17;
 public class Day17 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay17Data();
 
@@ -17,7 +17,7 @@ public class Day17 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay17Data();
 

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day18/Day18.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day18/Day18.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day18;
 public class Day18 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay18Data();
 
@@ -17,7 +17,7 @@ public class Day18 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay18Data();
 

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day19/Day19.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day19/Day19.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day19;
 public class Day19 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay19Data();
 
@@ -17,7 +17,7 @@ public class Day19 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay19Data();
 

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day20/Day20.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day20/Day20.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day20;
 public class Day20 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay20Data();
 
@@ -17,7 +17,7 @@ public class Day20 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay20Data();
 

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day21/Day21.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day21/Day21.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day21;
 public class Day21 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay21Data();
 
@@ -17,7 +17,7 @@ public class Day21 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay21Data();
 

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day22/Day22.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day22/Day22.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day22;
 public class Day22 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay22Data();
 
@@ -17,7 +17,7 @@ public class Day22 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay22Data();
 

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day23/Day23.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day23/Day23.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day23;
 public class Day23 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay23Data();
 
@@ -17,7 +17,7 @@ public class Day23 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay23Data();
 

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day24/Day24.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day24/Day24.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day24;
 public class Day24 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay24Data();
 
@@ -17,7 +17,7 @@ public class Day24 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay24Data();
 

--- a/Solvers/MBZ.AdventOfCode.Year2024/Days/Day25/Day25.cs
+++ b/Solvers/MBZ.AdventOfCode.Year2024/Days/Day25/Day25.cs
@@ -8,7 +8,7 @@ namespace MBZ.AdventOfCode.Year2024.Day25;
 public class Day25 : DaySolution, IDaySolutionImplementation
 {
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart1(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay25Data();
 
@@ -17,7 +17,7 @@ public class Day25 : DaySolution, IDaySolutionImplementation
     }
 
     [ExpectedResult(testResult: int.MaxValue, result: int.MaxValue)]
-    public override int RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
+    public override long RunPart2(bool isTest, string[] input, Action<OutputMessage> output)
     {
         var data = input.ParseToDay25Data();
 


### PR DESCRIPTION
Some puzzles will generate answers longer than Int. Make sure to return long results instead.